### PR TITLE
Add option to disable warning flags

### DIFF
--- a/hocon-compiler/src/Compiler.scala
+++ b/hocon-compiler/src/Compiler.scala
@@ -19,7 +19,7 @@ object Compiler {
     }
     val optionalInclude = opt[List[String]](short='D', default = Some(Nil)).map(_.toSet)
     val header = opt[String](default = Some(""))
-
+    val warnings = opt[Boolean](default = Some(false))
     val src = trailArg[File]()
 
     verify()
@@ -36,7 +36,7 @@ object Compiler {
       val configParser = new ConfigParser(opts.include(), opts.optionalInclude())
       val baseConfig = opts.base.toOption.map(configParser.parse)
       val mainConfig = configParser.parse(opts.src())
-      val merged = baseConfig.map(base => ConfigMerger.mergeOverrides(mainConfig, base)).getOrElse(mainConfig)
+      val merged = baseConfig.map(base => ConfigMerger.mergeOverrides(mainConfig, base, opts.warnings())).getOrElse(mainConfig)
 
       checkResolution(merged, opts.resolveLists())
 

--- a/hocon-compiler/src/ConfigMerger.scala
+++ b/hocon-compiler/src/ConfigMerger.scala
@@ -8,10 +8,12 @@ object ConfigMerger {
   /**
    * Merge overrides with base config
    */
-  def mergeOverrides(overrides: Config, base: Config): Config = {
-    val extraKeys = addedKeys(overrides, base)
-    if (extraKeys.nonEmpty) {
-      System.err.println(s"\u001b[31mWARN:\u001b[0m ${overrides.origin.filename} has config keys not in ${base.origin.filename}:\n\t${extraKeys.mkString("\n\t")}")
+  def mergeOverrides(overrides: Config, base: Config, warnings: Boolean): Config = {
+    if (warnings) {
+      val extraKeys = addedKeys(overrides, base)
+      if (extraKeys.nonEmpty) {
+        System.err.println(s"\u001b[31mWARN:\u001b[0m ${overrides.origin.filename} has config keys not in ${base.origin.filename}:\n\t${extraKeys.mkString("\n\t")}")
+      }
     }
     overrides.withFallback(base)
   }

--- a/rules/hocon.bzl
+++ b/rules/hocon.bzl
@@ -36,6 +36,8 @@ def _hocon_library_impl(ctx):
         args.add("-h", ctx.attr.header)
 
     args.add_all("-D", ctx.attr.optional_includes, omit_if_empty = True, uniquify = True)
+
+    args.add("--warnings", ctx.attr.warnings)
     args.add(ctx.file.src)
 
     args.use_param_file("@%s")
@@ -85,6 +87,11 @@ hocon_library = rule(
             mandatory = False,
         ),
         "out": attr.output(mandatory = True),
+        "warnings": attr.bool(
+            doc = """Specifies whether or not to see warnings about override config files with
+            config keys not in the base config.""",
+            default = False,
+        ),
         "_hocon_compiler": attr.label(
             executable = True,
             cfg = "host",


### PR DESCRIPTION
Add option to disable hocon warnings when override config files contain keys not found in the base file. By default, these warnings are now disabled.